### PR TITLE
Add JSON output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To run PwnAnalyzer, you need to provide a path to a JSON template file or a dire
 
 - `-t`, `--template`: Path to the JSON template file or directory containing JSON files (required).
 - `-c`, `--context`: Enable context printing around matched patterns (optional).
+- `-o`, `--output`: Write scan results to the specified JSON file (optional).
 
 ### Example Commands
 
@@ -48,6 +49,12 @@ Enable context printing:
 
 ```bash
 python PwnAnalyzer.py -t path/to/template.json -c
+```
+
+Save results to a JSON file:
+
+```bash
+python PwnAnalyzer.py -t path/to/template.json -o results.json
 ```
 
 ### Template schema

--- a/tests/test_pwn_analyzer.py
+++ b/tests/test_pwn_analyzer.py
@@ -61,3 +61,33 @@ def test_search_in_file_with_wildcard(tmp_path, capsys):
 
     assert str(file1) in captured
     assert str(file2) in captured
+
+
+def test_run_search_returns_results(tmp_path):
+    log_file = tmp_path / "attack.log"
+    log_file.write_text("something exploit happened\n")
+
+    template = {
+        "templates": [
+            {
+                "name": "ReturnTest",
+                "search_tasks": [
+                    {
+                        "file_path": str(log_file),
+                        "patterns": [
+                            {"pattern": "exploit", "case_sensitive": False, "severity": "high", "context_lines": 0, "actions": []}
+                        ]
+                    }
+                ],
+                "log_file": "test.log",
+            }
+        ]
+    }
+
+    template_file = tmp_path / "template.json"
+    template_file.write_text(json.dumps(template))
+
+    results = PwnAnalyzer.run_search(str(template_file), template_file.name, False)
+
+    assert len(results) == 1
+    assert results[0]["file"] == str(log_file)


### PR DESCRIPTION
## Summary
- return results from `run_search` and optionally collect results in the CLI
- allow saving found matches to a JSON file via the new `-o/--output` option
- document the new option in README
- test returning results from `run_search`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445ee0b5f883249dfd5780d2175e03